### PR TITLE
add click to insert

### DIFF
--- a/meta/todo.md
+++ b/meta/todo.md
@@ -6,9 +6,9 @@
 
 - [ ] Rendre hidden le bouton feedBack lorsque la zone de codeMirrorEditor est dirty
 
-- [ ] Implémenter système de score (q1 vaut 10 points, q2 = 20 points ...) les points seront sûrement stockées dans la table directement par commodité. 
-    - Bouton mise score -> Un slider pour miser un pourcentage de son score 10 à 50% de son score(?) 
-    - Dans local storage : { activityNumber }/{taskNumber}.
+- [ ] Implémenter système de score en utilisant `task.reward` généré à partir de SQLab 0.7.9.
+    - Bouton mise score -> Un slider pour miser un pourcentage de son score 10 à 50% de son score. 
+    - Dans local storage : `score/${activityNumber}`.
     - Plus tard logo de la monnaie du jeu au centre d'un slider circulaire, le pourcentage s'afficherait sur la pièce de monnaie.
 ## Prochainement
 - [ ] Aventure d'accueil/Tutoriel

--- a/public/components/tables/tables.js
+++ b/public/components/tables/tables.js
@@ -65,7 +65,7 @@ function generateTableRowsWithNumbers(rows, offset) {
     rows.forEach((row, i) => {
         const cells = row.map(cell => {
             const content = cell !== null ? escapeHtml(cell) : 'NULL';
-            return `<td class="insertable" title="${t('table.clickToAppend')}">${content}</td>`;
+            return `<td class="insertable" title="${t('table.clickToInsert')}">${content}</td>`;
         });
         rowsHtml.push(`<tr><td class="row-number">${offset + i + 1}</td>${cells.join('')}</tr>`);
     });
@@ -89,6 +89,11 @@ function addClickToInsert(tableElement) {
                 const editor = window.sqlEditor;
                 const cursor = editor.getCursor(); 
                 editor.replaceRange(textToInsert, cursor); 
+
+                this.classList.add('insert-success');
+                setTimeout(() => {
+                    this.classList.remove('insert-success');
+                }, 300);
             }
         });
 

--- a/public/components/tables/tables.js
+++ b/public/components/tables/tables.js
@@ -34,7 +34,7 @@ export function renderPaginatedTable(data, container, onPageChange) {
     const headers = generateTableHeaderRow(data.columns);
     const rows = generateTableRowsWithNumbers(data.rows, data.offset);
     tableElement.innerHTML = `<thead>${headers}</thead><tbody>${rows}</tbody>`;
-    addCellClickInteractions(tableElement);
+    addClickToInsert(tableElement);
 }
 
 // All the remaining functions are private and not exported
@@ -77,7 +77,7 @@ function generateTableRowsWithNumbers(rows, offset) {
  * - A visual effect indicates whether the copy to clipboard succeeded or failed.
  * - Double-click is disabled to prevent text selection.
  */
-function addCellClickInteractions(tableElement) {
+function addClickToInsert(tableElement) {
     tableElement.querySelectorAll('td.copyable').forEach(cell => {
         cell.addEventListener('click', async function() {
             const textToInsert = this.textContent.trim();

--- a/public/components/tables/tables.js
+++ b/public/components/tables/tables.js
@@ -34,7 +34,7 @@ export function renderPaginatedTable(data, container, onPageChange) {
     const headers = generateTableHeaderRow(data.columns);
     const rows = generateTableRowsWithNumbers(data.rows, data.offset);
     tableElement.innerHTML = `<thead>${headers}</thead><tbody>${rows}</tbody>`;
-    addClickToInsert(tableElement);
+    addClickToAppend(tableElement);
 }
 
 // All the remaining functions are private and not exported
@@ -77,17 +77,17 @@ function generateTableRowsWithNumbers(rows, offset) {
  * - A visual effect indicates whether the copy to clipboard succeeded or failed.
  * - Double-click is disabled to prevent text selection.
  */
-function addClickToInsert(tableElement) {
-    tableElement.querySelectorAll('td.copyable').forEach(cell => {
-        cell.addEventListener('click', async function() {
+function addClickToAppend(tableElement) {
+    tableElement.querySelectorAll('td.appendable').forEach(cell => {
+        cell.addEventListener('click', async function () {
             const textToInsert = this.textContent.trim();
 
            
             if (window.sqlEditor) {
-                const currentText = window.sqlEditor.getValue(); 
-                window.sqlEditor.setValue(currentText + ' ' + textToInsert); //on lui ajoute le texte cliqué avec un espace
                 //window.sqlEditor.focus(); // // Optional: puts the focus back into the editor
 
+                const currentText = window.sqlEditor.getValue();
+                window.sqlEditor.setValue(currentText + textToInsert); 
             }
         });
 

--- a/public/components/tables/tables.js
+++ b/public/components/tables/tables.js
@@ -30,12 +30,10 @@ export function mayRecreateTableContainerIn(container) {
  */
 export function renderPaginatedTable(data, container, onPageChange) {
     createPageStrip(container, data.offset, data.limit, data.total, onPageChange);
-    createPageStrip(container, data.offset, data.limit, data.total, onPageChange);
     const tableElement = container.querySelector('.table-content');
     const headers = generateTableHeaderRow(data.columns);
     const rows = generateTableRowsWithNumbers(data.rows, data.offset);
     tableElement.innerHTML = `<thead>${headers}</thead><tbody>${rows}</tbody>`;
-    addClickToInsert(tableElement);
     addClickToInsert(tableElement);
 }
 
@@ -75,12 +73,6 @@ function generateTableRowsWithNumbers(rows, offset) {
 }
 
 /**
- * Adds click and double-click event listeners to all table cells with the 'insertable' class within the given table element.
- *
- * On single click, the cell's trimmed text content is inserted to the value of a global SQL editor (window.sqlEditor), if it exists.
- * On double-click, prevents the default text selection behavior.
- *
- * @param {HTMLElement} tableElement - The table element containing cells to which event listeners will be attached.
  * Adds click and double-click event listeners to all table cells with the 'insertable' class within the given table element.
  *
  * On single click, the cell's trimmed text content is inserted to the value of a global SQL editor (window.sqlEditor), if it exists.

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -44,8 +44,7 @@
     "pagination": {
       "rows": "Rows"
     },
-    "nullValue": "NULL",
-    "clickToCopy": "Click to copy cell content"
+    "nullValue": "NULL"
   },
   "database": {
     "fetchError": "Failed to fetch database information: {status}",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -44,7 +44,8 @@
     "pagination": {
       "rows": "Rows"
     },
-    "nullValue": "NULL"
+    "nullValue": "NULL",
+    "clickToInsert" : "Click to insert cell content"
   },
   "database": {
     "fetchError": "Failed to fetch database information: {status}",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -44,7 +44,8 @@
     "pagination": {
       "rows": "Lignes"
     },
-    "nullValue": "NULL"
+    "nullValue": "NULL",
+    "clickToInsert" :"Cliquez pour insérer le contenu de la cellule"
   },
   "database": {
     "fetchError": "Impossible de récupérer les informations de la base de données : {status}",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -44,8 +44,7 @@
     "pagination": {
       "rows": "Lignes"
     },
-    "nullValue": "NULL",
-    "clickToCopy": "Cliquez pour copier le contenu de la cellule"
+    "nullValue": "NULL"
   },
   "database": {
     "fetchError": "Impossible de récupérer les informations de la base de données : {status}",

--- a/public/styles/components/tables.css
+++ b/public/styles/components/tables.css
@@ -66,34 +66,9 @@ tr:hover {
   border-right: 2px solid #ccc;
 }
 
-/* TODO : change this after making Click to insert*/
-/* == Click-to-copy styles for table cells == */
-td.copyable {
-  cursor: pointer;
-}
-
-td.copyable:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-
-td.copy-success {
-  animation: copy-success-flash 0.3s ease;
-}
-
-td.copy-error {
-  animation: copy-error-flash 0.3s ease;
-}
-
-@keyframes copy-success-flash {
-  0% { background-color: transparent; }
-  50% { background-color: #e6ffe6; }
-  100% { background-color: transparent; }
-}
-
-@keyframes copy-error-flash {
-  0% { background-color: transparent; }
-  50% { background-color: #ffe6e6; }
-  100% { background-color: transparent; }
+td.insert-success {
+    background-color: #d4edda;
+    transition: background-color 0.3s ease;
 }
 
 /* == Dark theme == */
@@ -123,4 +98,6 @@ td.copy-error {
 .dark-theme .row-number {
   color: #bbb;
 }
+
+
 


### PR DESCRIPTION
Rebonjour, après le merge de ce pull request j'en ferai un deuxième pour les tris car c'est dans le même fichier.
Dans la fonction : `addCellClickInteractions ` dans table.js on sélectionne tous les sélecteurs 'td.copyable' dans la table puis au déclenchement du click dans une case on récupère le texte de cette case et on l'insert dans l'éditeur code mirror : 
```javascript
const textToInsert = this.textContent.trim();

            if (window.sqlEditor) {
                const currentText = window.sqlEditor.getValue();
                window.sqlEditor.setValue(currentText + ' ' + textToInsert); 
            }
```
A la suite suivi d'un espace (on peut personnaliser ce qui précède)

Cette partie du code qui ne permet pas de sélectionner du code en double cliquant sur une case de cellule est optionnelle : 
```javascript
// Prevents text selection on double-click
        cell.addEventListener('dblclick', function (e) {
            e.preventDefault();
        });
´´´
        