### PR TITLE
fix falling coins

### DIFF
--- a/public/components/score/visualEffects.js
+++ b/public/components/score/visualEffects.js
@@ -5,7 +5,9 @@
 const EFFECT_DISPLAY_DURATION = 2000;
 const EFFECT_FADE_OUT_DURATION = 500;
 const FALLING_COIN_DURATION = 3000;
-const CELEBRATION_COIN_COUNT = 12;
+const MIN_FALLING_COIN_COUNT = 10;
+const MAX_FALLING_COIN_COUNT = 50;
+const FALLING_COIN_RATIO = 0.01;
 const COIN_DROP_INTERVAL = 100;
 const MAX_COIN_DELAY = 0.5;
 const MAX_COIN_ROTATION = 720;
@@ -86,7 +88,14 @@ export function initScoreVisualEffects() {
             body.appendChild(effect);
             if (amount > FALLING_COIN_THRESHOLD * score) {
                 // Show falling coins for big wins
-                for (let i = 0; i < CELEBRATION_COIN_COUNT; i++) {
+                const falling_coin_count = Math.max(
+                    MIN_FALLING_COIN_COUNT,
+                    Math.min(
+                        MAX_FALLING_COIN_COUNT,
+                        Math.floor(Math.abs(amount) * FALLING_COIN_RATIO)
+                    )
+                );
+                for (let i = 0; i < falling_coin_count; i++) {
                     setTimeout(() => {
                         createFallingCoin();
                     }, i * COIN_DROP_INTERVAL);

--- a/public/components/score/visualEffects.js
+++ b/public/components/score/visualEffects.js
@@ -17,7 +17,7 @@ const FALLING_COIN_THRESHOLD = 0.5;
  */
 export function initScoreVisualEffects() {
     const body = document.body;
-    
+
     /**
      * Creates a coin icon element
      * @param {string} className - The class name for the icon
@@ -49,11 +49,11 @@ export function initScoreVisualEffects() {
         amountText.textContent = `${amount} squalions`;
 
         const coin = createCoin('score-effect-coin');
-        
+
         content.appendChild(coin.cloneNode());
         content.appendChild(amountText);
         content.appendChild(coin.cloneNode());
-        
+
         overlay.appendChild(content);
         return overlay;
     }
@@ -82,7 +82,8 @@ export function initScoreVisualEffects() {
          * @param {number} amount - The amount won (positive) or lost (negative)
          */
         updateScore: (score, amount) => {
-           
+            const effect = createEffectOverlay(amount);
+            body.appendChild(effect);
             if (amount > FALLING_COIN_THRESHOLD * score) {
                 // Show falling coins for big wins
                 for (let i = 0; i < CELEBRATION_COIN_COUNT; i++) {
@@ -91,8 +92,7 @@ export function initScoreVisualEffects() {
                     }, i * COIN_DROP_INTERVAL);
                 }
             }
-            const effect = createEffectOverlay(amount);
-            body.appendChild(effect);
+
 
             // Trigger main animation
             requestAnimationFrame(() => effect.classList.add('active'));

--- a/public/styles/components/scoreVisualEffects.css
+++ b/public/styles/components/scoreVisualEffects.css
@@ -75,6 +75,7 @@
 /* == Falling coins animation == */
 .falling-coin {
     position: fixed;
+    top:-50px;
     width: 40px;
     height: 40px;
     z-index: 9998;

--- a/public/styles/components/scoreVisualEffects.css
+++ b/public/styles/components/scoreVisualEffects.css
@@ -75,7 +75,7 @@
 /* == Falling coins animation == */
 .falling-coin {
     position: fixed;
-    top:-50px;
+    top: -50px;
     width: 40px;
     height: 40px;
     z-index: 9998;


### PR DESCRIPTION
je repropose une correction en fait il manquait top: -50px; à .falling-coin donc elles popaient par défaut en bas de l'écran puis l'animation qui elle était bien définie à top:-50px se produisait au dessus 
Je l'ai pas vu tout à l'heure car parfois le navigateur le met en mode auto.