### PR TITLE
add checkbox to control sql auto-formatting in editor

### DIFF
--- a/public/components/menu/formatToggle.js
+++ b/public/components/menu/formatToggle.js
@@ -4,12 +4,10 @@
  */
 export function initSqlFormattingOption() {
     const formatSqlCheckbox = document.getElementById('format-sql-checkbox');
-    const formatSqlSetting = localStorage.getItem('formatSqlInEditor');
+    const formatSqlSetting = localStorage.getItem('formatSqlInEditor') || 'true';
 
     // Apply stored formatting preference (default is true if not set)
-    if (formatSqlSetting !== null) {
-        formatSqlCheckbox.checked = formatSqlSetting === 'true';
-    }
+    localStorage.setItem('formatSqlInEditor', formatSqlSetting);
 
     // Save formatting preference when changed
     formatSqlCheckbox.addEventListener('change', () => {

--- a/public/components/menu/formatToggle.js
+++ b/public/components/menu/formatToggle.js
@@ -1,0 +1,18 @@
+/**
+ * Initializes the SQL formatting option
+ * Handles the checkbox state and persistence
+ */
+export function initSqlFormattingOption() {
+    const formatSqlCheckbox = document.getElementById('format-sql-checkbox');
+    const formatSqlSetting = localStorage.getItem('formatSqlInEditor');
+
+    // Apply stored formatting preference (default is true if not set)
+    if (formatSqlSetting !== null) {
+        formatSqlCheckbox.checked = formatSqlSetting === 'true';
+    }
+
+    // Save formatting preference when changed
+    formatSqlCheckbox.addEventListener('change', () => {
+        localStorage.setItem('formatSqlInEditor', formatSqlCheckbox.checked);
+    });
+}

--- a/public/components/menu/hamburger.js
+++ b/public/components/menu/hamburger.js
@@ -1,0 +1,25 @@
+/**
+ * Initializes the hamburger menu functionality
+ * Handles menu toggle and outside click closing
+ */
+export function initHamburgerMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const dropdownMenu = document.querySelector('.dropdown-menu');
+
+    // Toggle dropdown menu visibility on hamburger icon click
+    menuToggle.addEventListener('click', (event) => {
+        event.stopPropagation(); // Prevent immediate closing
+        dropdownMenu.classList.toggle('active');
+        menuToggle.style.transform = dropdownMenu.classList.contains('active')
+            ? 'rotate(90deg)'
+            : 'rotate(0)';
+    });
+
+    // Close the menu when clicking outside
+    document.addEventListener('click', (event) => {
+        if (!event.target.closest('.hamburger-menu') && dropdownMenu.classList.contains('active')) {
+            dropdownMenu.classList.remove('active');
+            menuToggle.style.transform = 'rotate(0)';
+        }
+    });
+}

--- a/public/components/menu/themeToggle.js
+++ b/public/components/menu/themeToggle.js
@@ -1,0 +1,38 @@
+import { loadAndRenderRelationalSchema } from "../relationalSchema.js";
+
+/**
+ * Initializes the theme toggle functionality
+ * Handles dark/light theme switching and persistence
+ * @returns {boolean} Current theme state (true if dark)
+ */
+export function initThemeToggle() {
+    const themeToggle = document.getElementById('toggle-theme');
+    const isDarkTheme = localStorage.getItem('darkTheme') === 'true';
+
+    // Apply stored theme preference
+    if (isDarkTheme) {
+        document.body.classList.add('dark-theme');
+        document.querySelector('.moon-icon').classList.add('hidden');
+        document.querySelector('.sun-icon').classList.remove('hidden');
+    }
+
+    // Toggle dark/light theme and save preference
+    themeToggle.addEventListener('click', () => {
+
+        document.body.classList.toggle('dark-theme');
+        const isDark = document.body.classList.contains('dark-theme');
+        localStorage.setItem('darkTheme', isDark);
+        const moonIcon = document.querySelector('.moon-icon');
+        const sunIcon = document.querySelector('.sun-icon');
+        if (isDark) {
+            moonIcon.classList.add('hidden');
+            sunIcon.classList.remove('hidden');
+        } else {
+            moonIcon.classList.remove('hidden');
+            sunIcon.classList.add('hidden');
+        }
+        loadAndRenderRelationalSchema(isDark);
+    });
+
+    return isDarkTheme;
+}

--- a/public/components/score/stakeSystem.js
+++ b/public/components/score/stakeSystem.js
@@ -64,7 +64,7 @@ export function initStakeSystem(activityNumber) {
             // For the visual effect, use the local score
             window.scoreVisualEffects.updateScore(score, amount);
             // Update the local score to the new score, calculated server-side
-            score = parseInt(localStorage.getItem(scoreKey));
+            score = localStorage.getItem(scoreKey);
             scoreDisplay.textContent = `${score}`;
             updateCheckElements();
             checkButton.disabled = (score > 0);

--- a/public/components/score/stakeSystem.js
+++ b/public/components/score/stakeSystem.js
@@ -64,7 +64,7 @@ export function initStakeSystem(activityNumber) {
             // For the visual effect, use the local score
             window.scoreVisualEffects.updateScore(score, amount);
             // Update the local score to the new score, calculated server-side
-            score = localStorage.getItem(scoreKey);
+            score = parseInt(localStorage.getItem(scoreKey));
             scoreDisplay.textContent = `${score}`;
             updateCheckElements();
             checkButton.disabled = (score > 0);

--- a/public/components/tables/results.js
+++ b/public/components/tables/results.js
@@ -20,15 +20,6 @@ export function initQueryExecution() {
     window.sqlEditor.on('change', handleEditorChange);
 
     /**
-    * Checks if SQL formatting in editor is enabled
-    * @returns {boolean} True if formatting should be applied to the editor
-    */
-    function shouldFormatInEditor() {
-        const formatSqlCheckbox = document.getElementById('format-sql-checkbox');
-        return formatSqlCheckbox ? formatSqlCheckbox.checked : true;
-    }
-
-    /**
      * Set the behavior to trigger when the SQL editor content changes.
      * 
      * Depending on whether this content is empty or not, it will:
@@ -78,7 +69,7 @@ export function initQueryExecution() {
             functionCase: 'lower',
             linesBetweenQueries: 2,
         });
-        if (shouldFormatInEditor()) {
+        if (window.localStorage.getItem('formatSqlInEditor') === 'true') {
             window.sqlEditor.setValue(query);
         }
 

--- a/public/components/tables/results.js
+++ b/public/components/tables/results.js
@@ -20,6 +20,15 @@ export function initQueryExecution() {
     window.sqlEditor.on('change', handleEditorChange);
 
     /**
+    * Checks if SQL formatting in editor is enabled
+    * @returns {boolean} True if formatting should be applied to the editor
+    */
+    function shouldFormatInEditor() {
+        const formatSqlCheckbox = document.getElementById('format-sql-checkbox');
+        return formatSqlCheckbox ? formatSqlCheckbox.checked : true;
+    }
+
+    /**
      * Set the behavior to trigger when the SQL editor content changes.
      * 
      * Depending on whether this content is empty or not, it will:
@@ -69,7 +78,10 @@ export function initQueryExecution() {
             functionCase: 'lower',
             linesBetweenQueries: 2,
         });
-        window.sqlEditor.setValue(query);
+        if (shouldFormatInEditor()) {
+            window.sqlEditor.setValue(query);
+        }
+
         const result = await runQueryAndRenderResults(query);
         executionTab.removeEventListener('click', triggerExecutionOfNewQuery);
         setTabIconTo(checkIcon);
@@ -100,7 +112,7 @@ export function initQueryExecution() {
             // Render the paginated table with results and page change handler
             renderPaginatedTable(data, resultsContainer, changePage);
             return data;
-            
+
         } catch (error) {
             showError(error.message, resultsContainer);
             return null;

--- a/public/index.html
+++ b/public/index.html
@@ -53,7 +53,16 @@
                         </svg>
                     </div>
                 </div>
+                <!-- SQL Formatting option -->
+                <div class="menu-item formatting-container">
+                    <span class="menu-label" data-i18n="header.formatSql">Format SQL in editor</span>
+                    <div class="checkbox-container">
+                        <input type="checkbox" id="format-sql-checkbox" checked>
+                        <label for="format-sql-checkbox" class="checkbox-label"></label>
+                    </div>
+                </div>
             </div>
+        </div>
         </div>
 
         <!-- Title -->

--- a/public/localization/locales/en.json
+++ b/public/localization/locales/en.json
@@ -7,11 +7,7 @@
     "toggleTheme": "Toggle theme",
     "language": "Interface",
     "theme": "Theme",
-    "formatSql": "Auto-format SQL"
-  },
-  "context": {
-    "loading": "Loading episode...",
-    "loadError": "Failed to load episode content"
+    "formatSql": "Format my queries"
   },
   "query": {
     "placeholder": "Enter your SQL query here...\nTip: clicking the task number again pre-fills a query with the expected column names.",

--- a/public/localization/locales/en.json
+++ b/public/localization/locales/en.json
@@ -6,7 +6,8 @@
   "header": {
     "toggleTheme": "Toggle theme",
     "language": "Interface",
-    "theme": "Theme"
+    "theme": "Theme",
+    "formatSql": "Auto-format SQL"
   },
   "context": {
     "loading": "Loading episode...",

--- a/public/localization/locales/fr.json
+++ b/public/localization/locales/fr.json
@@ -7,11 +7,7 @@
     "toggleTheme": "Changer de thème",
     "language": "Interface",
     "theme": "Thème",
-    "formatSql": "Formatter automatiquement"
-  },
-  "context": {
-    "loading": "Chargement de l'épisode...",
-    "loadError": "Impossible de charger le contenu de l'épisode"
+    "formatSql": "Formater mes requêtes"
   },
   "query": {
     "placeholder": "Entrez ici votre requête SQL...\nAstuce : cliquer à nouveau sur le numéro de la tâche en cours pré-compose une requête avec le nom des colonnes attendues.",

--- a/public/localization/locales/fr.json
+++ b/public/localization/locales/fr.json
@@ -6,7 +6,8 @@
   "header": {
     "toggleTheme": "Changer de thème",
     "language": "Interface",
-    "theme": "Thème"
+    "theme": "Thème",
+    "formatSql": "Formatter automatiquement"
   },
   "context": {
     "loading": "Chargement de l'épisode...",

--- a/public/main.js
+++ b/public/main.js
@@ -33,10 +33,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadAndRenderActivityTitle();
     await loadAndRenderTableOfContents();
 
+
+    // Load the settings
+    const isDarkTheme = initThemeToggle();
+    initSqlFormattingOption(); // before initQueryExecution
+    initHamburgerMenu();
+
+
     // Initialize core components: tabs, query handling, and core tables
     initTabs();
     document.querySelector('.tab[data-tab="schema-tab"]').click();
-    initQueryExecution();
+    initQueryExecution(); // after initSqlFormattingOption
     initNotes();
 
     // Initialize the task strip and simulate a click on the active button
@@ -52,10 +59,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Automatically load core tables on page load
     window.loadAndRenderCoreTableList();
-
-    const isDarkTheme = initThemeToggle();
-    initSqlFormattingOption();
-    initHamburgerMenu();
 
     // Load relational schema with current theme
     await loadAndRenderRelationalSchema(isDarkTheme);

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,5 @@
 import { loadAndRenderActivityTitle } from './components/activityTitle.js';
-import { loadAndRenderTableOfContents} from './components/toc.js';
+import { loadAndRenderTableOfContents } from './components/toc.js';
 import { loadAndRenderRelationalSchema } from './components/relationalSchema.js';
 import { loadAndRenderCoreTableList } from './components/tables/core/accordions.js';
 import { loadAndRenderCoreTableData } from './components/tables/core/data.js';
@@ -9,7 +9,9 @@ import { initQueryExecution } from './components/tables/results.js';
 import { initNotes } from './components/notes.js';
 import { createTaskStrip } from './components/strips/tasks.js';
 import { initFeedback } from './components/feedback.js';
-
+import { initThemeToggle } from './components/menu/themeToggle.js';
+import { initHamburgerMenu } from './components/menu/hamburger.js';
+import { initSqlFormattingOption } from './components/menu/formatToggle.js';
 import { TEMP_STARTING_ACTIVITY } from './utils/constants.js';
 import { initSqlEditor } from './components/sqlEditor.js';
 
@@ -51,66 +53,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Automatically load core tables on page load
     window.loadAndRenderCoreTableList();
 
-    // Theme toggle handling
-    const themeToggle = document.getElementById('toggle-theme');
-    const isDarkTheme = localStorage.getItem('darkTheme') === 'true';
+    const isDarkTheme = initThemeToggle();
+    initSqlFormattingOption();
+    initHamburgerMenu();
 
-    // Apply stored theme preference
-    if (isDarkTheme) {
-        document.querySelector('.moon-icon').classList.add('hidden');
-        document.querySelector('.sun-icon').classList.remove('hidden');
-    }
+    // Load relational schema with current theme
     await loadAndRenderRelationalSchema(isDarkTheme);
-
-    // Toggle dark/light theme and save preference
-    themeToggle.addEventListener('click', () => {
-        document.body.classList.toggle('dark-theme');
-        const isDark = document.body.classList.contains('dark-theme');
-
-        // Save user preference
-        localStorage.setItem('darkTheme', isDark);
-
-        const moonIcon = document.querySelector('.moon-icon');
-        const sunIcon = document.querySelector('.sun-icon');
-        // Update icon based on theme
-        if (isDark) {
-            moonIcon.classList.add('hidden');
-            sunIcon.classList.remove('hidden');
-        } else {
-            moonIcon.classList.remove('hidden');
-            sunIcon.classList.add('hidden');
-        }
-
-        // Reload relational schema with the new theme
-        loadAndRenderRelationalSchema(isDark);
-    });
-
-    // hamburger menu handling
-    const menuToggle = document.getElementById('menu-toggle');
-    const dropdownMenu = document.querySelector('.dropdown-menu');
-
-    if (menuToggle && dropdownMenu) {
-        // Toggle dropdown menu visibility on hamburger icon click
-        menuToggle.addEventListener('click', (event) => {
-            event.stopPropagation(); // Prevent immediate closing
-            dropdownMenu.classList.toggle('active');
-
-            // Optional icon rotation for visual feedback
-            menuToggle.style.transform = dropdownMenu.classList.contains('active')
-                ? 'rotate(90deg)'
-                : 'rotate(0)';
-        });
-
-        // Close the menu when clicking outside
-        document.addEventListener('click', (event) => {
-            if (!event.target.closest('.hamburger-menu') && dropdownMenu.classList.contains('active')) {
-                dropdownMenu.classList.remove('active');
-                menuToggle.style.transform = 'rotate(0)';
-            }
-        });
-    }
 });
-
-
-
-

--- a/public/styles/components/header.css
+++ b/public/styles/components/header.css
@@ -85,6 +85,7 @@ h1 {
     font-size: var(--font-size-sm);
     color: var(--color-dark);
     margin-right: var(--spacing-md);
+    text-wrap: nowrap;
 }
 
 .menu-item .theme-icon {

--- a/public/styles/components/header.css
+++ b/public/styles/components/header.css
@@ -132,6 +132,47 @@ h1 {
     display: none;
 }
 
+/* ===== Checkbox for SQL formatting ===== */
+.checkbox-container {
+    display: flex;
+    align-items: center;
+}
+
+#format-sql-checkbox {
+    display: none;
+}
+
+
+.checkbox-label {
+    position: relative;
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--color-primary);
+    border-radius: var(--border-radius-sm);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition-fast);
+}
+
+.checkbox-label::after {
+    content: '✓';
+    color: var(--color-white);
+    font-size: 12px;
+    font-weight: bold;
+    opacity: 0;
+    transition: opacity var(--transition-fast);
+}
+
+#format-sql-checkbox:checked + .checkbox-label {
+    background-color: var(--color-primary);
+}
+
+#format-sql-checkbox:checked + .checkbox-label::after {
+    opacity: 1;
+}
+
 /*  ====  Score ===== */
 .score-display {
     position: absolute;


### PR DESCRIPTION
J'ai rajouté le bouton checkbox, je récupère la valeur de l'attribut checked dans` result.js,` si c'est true on met la requête formatée dans l'éditeur : 
```javascript
  if (shouldFormatInEditor()) {
            window.sqlEditor.setValue(query);
        }
```
Je peux retirer la fonction mais je dois alors avoir une déclaration de variable en plein dans la fonction triggerExecutionNewQuery() pour récupérer l'attribut de la div : 
`const formatSqlCheckbox = document.getElementById('format-sql-checkbox');`
(Il faut pas déclarer la variable à l'initialisation car la valeur est changée dans le temps par l'utilisateur)

J'ai aussi créé un dossier menu où j'y ai mis 3 fichiers pour les initialisations du thème, du menu déroulant, et de la logique de la checkbox car ça commencait à encombrer main.js, même si ça a vocation à aller sur la page d'accueil plus tard au moins ça sera plus facile à retrouver 